### PR TITLE
Revert Jena Libs Dependency Change in Pom #34

### DIFF
--- a/src/store-core/pom.xml
+++ b/src/store-core/pom.xml
@@ -62,9 +62,19 @@
 
     <!-- Jena -->
     <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>apache-jena-libs</artifactId>
-      <type>pom</type>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-tdb</artifactId>
+        <version>3.6.0</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-tdb2</artifactId>
+        <version>3.6.0</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-rdfconnection</artifactId>
+        <version>3.6.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>


### PR DESCRIPTION
Replaced Jena-Libs POM type dependency with the dependencies within this POM file.

Change-Id: If1102010746cf03b948e99eef1f96a8fdbcc6fc1
Signed-off-by: Yash Khatri <yash.khatri@scania.com>