### PR TITLE
Handle oslc.where queries of strings that happen to contain an integer value. Also support for Integers.

### DIFF
--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
@@ -55,6 +55,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lyo.core.query.ComparisonTerm;
 import org.eclipse.lyo.core.query.ComparisonTerm.Operator;
+import org.eclipse.lyo.core.query.DecimalValue;
 import org.eclipse.lyo.core.query.PName;
 import org.eclipse.lyo.core.query.ParseException;
 import org.eclipse.lyo.core.query.QueryUtils;
@@ -548,9 +549,13 @@ public class SparqlStoreImpl implements Store {
     				}
     				
     				switch (operandType) {
+    				case DECIMAL:
+    					DecimalValue decimalOperand = (DecimalValue) comparisonOperand;
+    			        distinctResourcesQuery.addWhere( "?s", predicate, decimalOperand.value());
+    					break;
     				case STRING:
     					StringValue stringOperand = (StringValue) comparisonOperand;
-    			        distinctResourcesQuery.addWhere( "?s", predicate, stringOperand.value());
+    			        distinctResourcesQuery.addWhere( "?s", predicate, "\"" + stringOperand.value() + "\"");
     					break;
     				case URI_REF:
     					UriRefValue uriOperand = (UriRefValue) comparisonOperand;

--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
@@ -562,7 +562,7 @@ public class SparqlStoreImpl implements Store {
     			        distinctResourcesQuery.addWhere( "?s", predicate,  new ResourceImpl(uriOperand.value()));
     					break;
     				default:
-    			        throw new UnsupportedOperationException("only support for terms of type Comparisons, where the operator is 'EQUALS', and the operand is either a String or a URI");
+    			        throw new UnsupportedOperationException("only support for terms of type Comparisons, where the operator is 'EQUALS', and the operand is either a String, an Integer or a URI");
     				}
     			}
         	}

--- a/src/store-core/src/test/java/org/eclipse/lyo/store/JenaTdbStoreImplIT.java
+++ b/src/store-core/src/test/java/org/eclipse/lyo/store/JenaTdbStoreImplIT.java
@@ -109,4 +109,16 @@ public class JenaTdbStoreImplIT extends StoreTestBase<JenaTdbStoreImpl> {
             throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
     }
 
+    @Override
+    @Ignore("Not implemented yet")
+    public void testStoreQueryWithWhereFilterOnStringsWithIntegerValue()
+            throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
+    }
+
+    @Override
+    @Ignore("Not implemented yet")
+    public void testStoreQueryWithWhereFilterOnIntegers()
+            throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
+    }
+
 }

--- a/src/store-core/src/test/java/org/eclipse/lyo/store/JenaTdbStoreImplPathsIT.java
+++ b/src/store-core/src/test/java/org/eclipse/lyo/store/JenaTdbStoreImplPathsIT.java
@@ -90,4 +90,16 @@ public class JenaTdbStoreImplPathsIT extends StoreTestBase<JenaTdbStoreImpl> {
             throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
     }
 
+    @Override
+    @Ignore("Not implemented yet")
+    public void testStoreQueryWithWhereFilterOnStringsWithIntegerValue()
+            throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
+    }
+
+    @Override
+    @Ignore("Not implemented yet")
+    public void testStoreQueryWithWhereFilterOnIntegers()
+            throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
+    }
+
 }

--- a/src/store-core/src/test/java/org/eclipse/lyo/store/JenaTdbStoreImplTest.java
+++ b/src/store-core/src/test/java/org/eclipse/lyo/store/JenaTdbStoreImplTest.java
@@ -91,4 +91,16 @@ public class JenaTdbStoreImplTest extends StoreTestBase<JenaTdbStoreImpl> {
             throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
     }
 
+    @Override
+    @Ignore("Not implemented yet")
+    public void testStoreQueryWithWhereFilterOnStringsWithIntegerValue()
+            throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
+    }
+
+    @Override
+    @Ignore("Not implemented yet")
+    public void testStoreQueryWithWhereFilterOnIntegers()
+            throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
+    }
+    
 }

--- a/src/store-core/src/test/java/org/eclipse/lyo/store/StoreTestBase.java
+++ b/src/store-core/src/test/java/org/eclipse/lyo/store/StoreTestBase.java
@@ -36,6 +36,7 @@ import org.eclipse.lyo.oslc4j.core.model.IResource;
 import org.eclipse.lyo.oslc4j.core.model.ServiceProviderCatalog;
 import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
 import org.eclipse.lyo.store.resources.BlankResource;
+import org.eclipse.lyo.store.resources.Nsp1DomainConstants;
 import org.eclipse.lyo.store.resources.Requirement;
 import org.eclipse.lyo.store.resources.WithBlankResource;
 import org.eclipse.lyo.store.resources.WithTwoDepthBlankResource;
@@ -376,6 +377,31 @@ public abstract class StoreTestBase<T extends Store> {
 
     }
 
+
+    @Test
+    public void testStoreQueryWithWhereFilterOnStringsWithIntegerValue()
+            throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
+        final T manager = buildStore();
+        final URI namedGraphUri = buildKey();
+        populateStore(manager, namedGraphUri);
+
+        List<Requirement> requirements = manager.getResources(namedGraphUri, Requirement.class,
+                "prf=<" + Nsp1DomainConstants.TESTDOMAIN_NAMSPACE + ">", "prf:stringProperty=\"2\"", null, -1, -1);
+        Assertions.assertThat(requirements).hasSize(1);
+    }
+
+    @Test
+    public void testStoreQueryWithWhereFilterOnIntegers()
+            throws StoreAccessException, ModelUnmarshallingException, URISyntaxException {
+        final T manager = buildStore();
+        final URI namedGraphUri = buildKey();
+        populateStore(manager, namedGraphUri);
+
+        List<Requirement> requirements = manager.getResources(namedGraphUri, Requirement.class,
+                "prf=<" + Nsp1DomainConstants.TESTDOMAIN_NAMSPACE + ">", "prf:intProperty=3", null, -1, -1);
+        Assertions.assertThat(requirements).hasSize(2);
+    }
+
     protected abstract T buildStore();
 
     private URI buildKey() {
@@ -392,27 +418,29 @@ public abstract class StoreTestBase<T extends Store> {
         return resource;
     }
     
-	private Requirement createRequirement(String identifier, String description) throws URISyntaxException {
+	private Requirement createRequirement(String identifier, String description, String stringProperty, int intProperty) throws URISyntaxException {
 		Requirement r = new Requirement(buildKey());
 		r.setIdentifier(identifier);
 		r.setDescription(description);
+		r.setStringProperty(stringProperty);
+		r.setIntProperty(intProperty);
 		return r;
 	}
 
     private void populateStore(final T manager, final URI namedGraphUri)
             throws StoreAccessException, URISyntaxException {
         manager.appendResource(namedGraphUri,
-                createRequirement("rob", "Tom got a small piece of pie. Rock music approaches at high velocity."));
+                createRequirement("rob", "Tom got a small piece of pie. Rock music approaches at high velocity.", "s-1", 1));
         manager.appendResource(namedGraphUri, createRequirement("hang",
-                "She borrowed the book from him many years ago and hasn't yet returned it. Please wait outside of the house. The river stole the gods."));
+                "She borrowed the book from him many years ago and hasn't yet returned it. Please wait outside of the house. The river stole the gods.", "2", 2));
         manager.appendResource(namedGraphUri, createRequirement("observations",
-                "We have never been to Asia, nor have we visited Africa. Malls are great places to shop; I can find everything I need under one roof."));
+                "We have never been to Asia, nor have we visited Africa. Malls are great places to shop; I can find everything I need under one roof.", "s-3", 3));
         manager.appendResource(namedGraphUri, createRequirement("kindly",
-                "I think I will buy the red car, or I will lease the blue one. The river stole the gods."));
+                "I think I will buy the red car, or I will lease the blue one. The river stole the gods.", "s-4", 3));
         manager.appendResource(namedGraphUri, createRequirement("itch",
-                "A song can make or ruin a person’s day if they let it get to them. The body may perhaps compensates for the loss of a true metaphysics."));
+                "A song can make or ruin a person’s day if they let it get to them. The body may perhaps compensates for the loss of a true metaphysics.", "s-5", 5));
         manager.appendResource(namedGraphUri, createRequirement("morning",
-                "They got there early, and they got really good seats. Lets all be unique together until we realise we are all the same."));
+                "They got there early, and they got really good seats. Lets all be unique together until we realise we are all the same.", "s-6", 6));
         manager.appendResource(namedGraphUri, buildResource());
     }
 

--- a/src/store-core/src/test/java/org/eclipse/lyo/store/resources/Requirement.java
+++ b/src/store-core/src/test/java/org/eclipse/lyo/store/resources/Requirement.java
@@ -32,7 +32,9 @@ public class Requirement
     private String identifier;
     private Date created;
     private HashSet<Link> decomposes = new HashSet<Link>();
-    
+    private String stringProperty;
+    private Integer intProperty;
+
     public Requirement()
            throws URISyntaxException
     {
@@ -100,6 +102,26 @@ public class Requirement
         return decomposes;
     }
     
+    @OslcName("stringProperty")
+    @OslcPropertyDefinition(Nsp1DomainConstants.TESTDOMAIN_NAMSPACE + "stringProperty")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcValueType(ValueType.String)
+    @OslcReadOnly(false)
+    public String getStringProperty()
+    {
+        return stringProperty;
+    }
+    
+    @OslcName("intProperty")
+    @OslcPropertyDefinition(Nsp1DomainConstants.TESTDOMAIN_NAMSPACE + "intProperty")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcValueType(ValueType.Integer)
+    @OslcReadOnly(false)
+    public Integer getIntProperty()
+    {
+        return intProperty;
+    }
+
     public void setTitle(final String title )
     {
         this.title = title;
@@ -131,5 +153,14 @@ public class Requirement
         }
     }
     
+    public void setStringProperty(final String stringProperty )
+    {
+        this.stringProperty = stringProperty;
+    }
+    
+    public void setIntProperty(final Integer intProperty )
+    {
+        this.intProperty = intProperty;
+    }
     
 }


### PR DESCRIPTION
Handle oslc.where queries of strings that happen to contain an integer value (example "123").
For some reason, the Jena QueryBuilder properly handle the creation of a where query where the string is "s-123", adding the expected "quotes" to the query. But for a string of value "123", the quotes are not added.

While at it, extend oslc.where queries to also support integers. Otherwise, I could not be sure that the solultion for the problem above is stable.

This problem is first reported under https://forum.open-services.net/t/lyo-store-oslc-query-with-sparql-issues-with-the-where-clause/224
