### PR TITLE
Improve of the search SPARQL query

### DIFF
--- a/src/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
+++ b/src/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
@@ -587,7 +587,6 @@ public class SparqlStoreImpl implements Store {
         
         SelectBuilder constructSelectQuery = new SelectBuilder();
         constructSelectQuery.addVar( "s p o" )
-        	.addWhere( "?s", "?p", "?o")
         	.addSubQuery(distinctResourcesQuery);
 
         return constructSelectQuery;


### PR DESCRIPTION
The current sparql query for searching is:

```
DESCRIBE ?s
WHERE
  { GRAPH <urn:x-arq:DefaultGraph>
      { ?s  ?p  ?o
        { SELECT   DISTINCT ?s
          WHERE
            { ?s  ?p        ?o ;
                  rdf:type  <http://...#SomeType>
                  FILTER regex(str(?o), "someText", "i")
            }
          LIMIT   1
        }
      }}
```

This turns out to be too slow. Removing the `?s  ?p  ?o` on the 4th line dramatically improves the query speed, without affecting the search result.
Query is tested with both Fuseki and Marklogic.
